### PR TITLE
Update kusama.json > helixstreet new stash/name

### DIFF
--- a/candidates/kusama.json
+++ b/candidates/kusama.json
@@ -4218,8 +4218,8 @@
     },
     {
       "slotId": 613,
-      "name": "helixstreet",
-      "stash": "J6K1vA6ynGo2GrotGpP5ocHKr82JFTv7NUnzJcoRfTcCn8T",
+      "name": "helixstreet/4",
+      "stash": "DGvPFG7dHMWryfHQD2XBQ4WX1nM5KnyHmsLSj2k7DaBRhUD",
       "riotHandle": "@helixstreet.io:matrix.org",
       "kyc": false
     },


### PR DESCRIPTION
1/
reasoning: the old validator appears to be self-sufficient  
2/
additional note: the identity for this stash work in progress on the people chain.